### PR TITLE
Use CGI.escape rather than URI.escape

### DIFF
--- a/lib/semantics3.rb
+++ b/lib/semantics3.rb
@@ -8,6 +8,7 @@
 require 'rubygems'
 require 'oauth'
 require 'uri'
+require 'cgi'
 require 'json'
 
 module Semantics3
@@ -29,7 +30,7 @@ module Semantics3
 
         #returns a value
         def _make_request(endpoint, params)
-            url = 'https://api.semantics3.com/v1/' + endpoint + '?q=' + URI.escape(params)
+            url = 'https://api.semantics3.com/v1/' + endpoint + '?q=' + CGI.escape(params)
 
             #puts "url = #{url}"
             response = @auth.get(url)


### PR DESCRIPTION
Its recommend to use CGI.escape instead of URI.escape.

https://github.com/ruby/ruby/commit/238b979f1789f95262a267d8df6239806f2859cc#diff-5aecce86ef66006d6771d4e81587be2cR504

Here is a Stack Overflow post about it as well.

http://stackoverflow.com/questions/2824126/whats-the-difference-between-uri-escape-and-cgi-escape#answer-13059657

Your API kept sending me errors about not being encoded.

After updating to this, I started getting better results.
